### PR TITLE
Fix IOError caused by negative sleep time

### DIFF
--- a/learnthings.py
+++ b/learnthings.py
@@ -60,7 +60,7 @@ class Thing:
         # play sounds
         if self.namesound:
             self.namesound.play()
-            time.sleep(self.namesound.get_length() - 0.5)
+            time.sleep(max(0, self.namesound.get_length() - 0.5))
         if self.sound:
             self.sound.play()
 


### PR DESCRIPTION
There are some English "namesound" files with a length less than 0.5 seconds: cat, dog, duck, pig, sheep. The resulting sleep time < 0 caused an IOError (crash) on Linux, Python 2.7.6.
